### PR TITLE
feat: add judgement bar overlay for hit timing visualization

### DIFF
--- a/src/Config/ModConfig.cs
+++ b/src/Config/ModConfig.cs
@@ -89,6 +89,12 @@ public static class ModConfig
     public static ConfigEntry<float> HitOffsetRyoRange { get; private set; } = ConfigEntry<float>.Noop;
 
     // =========================================================================
+    // JudgementBar 节
+    // =========================================================================
+    public static ConfigEntry<bool> EnableJudgementBar { get; private set; } = ConfigEntry<bool>.Noop;
+    public static ConfigEntry<float> JudgementBarTimeRange { get; private set; } = ConfigEntry<float>.Noop;
+
+    // =========================================================================
     // BilibiliLiveStreamSongRequest 节
     // =========================================================================
     public static ConfigEntry<bool> EnableBilibiliLiveStreamSongRequest { get; private set; } = ConfigEntry<bool>.Noop;
@@ -172,6 +178,12 @@ public static class ModConfig
             EnableHitOffset = s.Bool("Enable", "config.HitOffset.Enable", false);
             HitOffsetInvertColor = s.Bool("InvertColor", "config.HitOffset.InvertColor", false);
             HitOffsetRyoRange = s.Float("RyoRange", "config.HitOffset.RyoRange", -1f);
+        });
+
+        ConfigSectionBuilder.Section("JudgementBar", s =>
+        {
+            EnableJudgementBar = s.Bool("Enable", "config.JudgementBar.Enable", false);
+            JudgementBarTimeRange = s.Float("TimeRange", "config.JudgementBar.TimeRange", 150f);
         });
 
         ConfigSectionBuilder.Section("BilibiliLiveStreamSongRequest", s =>
@@ -267,6 +279,12 @@ public static class ModConfig
         AddFloat("HitOffset", "RyoRange", Description("config.HitOffset.RyoRange"), HitOffsetRyoRange, "Enso",
             "EnsoTest");
 
+        // JudgementBar
+        AddBool("JudgementBar", "Enable", Description("config.JudgementBar.Enable"), EnableJudgementBar, "Enso",
+            "EnsoTest");
+        AddFloat("JudgementBar", "TimeRange", Description("config.JudgementBar.TimeRange"), JudgementBarTimeRange,
+            "Enso", "EnsoTest");
+
         // BilibiliLiveStreamSongRequest
         AddBool("BilibiliLiveStreamSongRequest", "Enable", Description("config.BilibiliLiveStreamSongRequest.Enable"),
             EnableBilibiliLiveStreamSongRequest, "Boot", "SongSelect", "Enso");
@@ -326,6 +344,7 @@ public static class ModConfig
             "General.AutoPlayRendaSpeed",
             "HitOffset.InvertColor",
             "HitOffset.RyoRange",
+            "JudgementBar.TimeRange",
             "CustomPlayerName.Name",
             "BufferedInput.Enable",
             "BufferedInput.MaxBufferedInputCount",

--- a/src/Patches/EnsoGameBasePatch.cs
+++ b/src/Patches/EnsoGameBasePatch.cs
@@ -134,6 +134,8 @@ public class EnsoGameBasePatch
     private static void OnSimpleHit(int playerNum, TaikoCoreTypes.HitResultTypes hitResult, float onpuJustTime)
     {
         PlayerStates[playerNum].RecordHit(hitResult, onpuJustTime);
+        if (playerNum == 0 && ModConfig.EnableJudgementBar.Value)
+            TnTRFMod.Scenes.Enso.JudgementBarOverlay.PushHitOffsetFromPatch(onpuJustTime);
     }
 
     private static void OnRendaHit(int playerNum)

--- a/src/Resources/Locales.toml
+++ b/src/Resources/Locales.toml
@@ -130,6 +130,9 @@ config.HitOffset.Enable = "启用音符敲击时差指示器"
 config.HitOffset.InvertColor = "反转快/慢音符偏移文本颜色"
 config.HitOffset.RyoRange = "音符的良判范围（单位正负毫秒），设置为 -1f 可跟随所选歌曲难度"
 
+config.JudgementBar.Enable = "启用判定误差条（在演奏画面底部显示击打时差分布图）"
+config.JudgementBar.TimeRange = "判定误差条的最大显示范围（单位正负毫秒）"
+
 config.BilibiliLiveStreamSongRequest.Enable = "启用 Bilibili 直播点歌功能"
 config.BilibiliLiveStreamSongRequest.RoomId = "Bilibili 站直播间 ID"
 config.BilibiliLiveStreamSongRequest.Token = """Bilibili 站直播间 Token
@@ -307,6 +310,9 @@ config.HitOffset.Enable = "Enable hit offset during play."
 config.HitOffset.InvertColor = "Invert color of fast/late hit offset text."
 config.HitOffset.RyoRange = "Define the GOOD judgement range of note in positive ms, set to -1f to follow the difficulty of selected song course."
 
+config.JudgementBar.Enable = "Enable the judgement error bar overlay (displays hit timing distribution at the bottom of the play screen)."
+config.JudgementBar.TimeRange = "Maximum display range of the judgement bar in positive ms."
+
 config.BilibiliLiveStreamSongRequest.Enable = "Enable Bilibili Live Stream Song Request."
 config.BilibiliLiveStreamSongRequest.RoomId = "Bilibili Live Stream Room ID."
 config.BilibiliLiveStreamSongRequest.Token = "Bilibili Live Stream Token. Commonly as a Cookie called 'SESSDATA'. If you don't provide this, you won't be able to get accurate sender info."
@@ -475,6 +481,9 @@ config.Debug.ExportMusicNames = "内蔵曲名リストを書き出す（デバ�
 config.HitOffset.Enable = "演奏中にタイミングのズレを表示"
 config.HitOffset.InvertColor = "早/遅の色を反転"
 config.HitOffset.RyoRange = "良判定の許容幅（ms）。-1f で難易度依存。"
+
+config.JudgementBar.Enable = "判定誤差バーを有効化（演奏画面下部にタイミング分布を表示）"
+config.JudgementBar.TimeRange = "判定誤差バーの最大表示範囲（ms）"
 
 config.BilibiliLiveStreamSongRequest.Enable = "Bilibili 生放送のリクエスト機能"
 config.BilibiliLiveStreamSongRequest.RoomId = "Bilibili 生放送のルーム ID"
@@ -646,6 +655,9 @@ config.Debug.ExportMusicNames = "Exporter la liste interne des chansons (débug)
 config.HitOffset.Enable = "Afficher l'indicateur d'avance/retard"
 config.HitOffset.InvertColor = "Inverser les couleurs rapide/lent"
 config.HitOffset.RyoRange = "Fenetre de BONs en ms (+/-). -1f pour suivre la difficulté."
+
+config.JudgementBar.Enable = "Afficher la barre de timing (distribution de la precision des frappes en bas de l'ecran de jeu)."
+config.JudgementBar.TimeRange = "Plage d'affichage maximale de la barre de timing en ms."
 
 config.BilibiliLiveStreamSongRequest.Enable = "Activer les requêtes de morceaux Bilibili Live"
 config.BilibiliLiveStreamSongRequest.RoomId = "ID de salon Bilibili Live"

--- a/src/Scenes/Enso/JudgementBarOverlay.cs
+++ b/src/Scenes/Enso/JudgementBarOverlay.cs
@@ -1,0 +1,399 @@
+using TnTRFMod.Config;
+using TnTRFMod.Patches;
+using TnTRFMod.Ui;
+using TnTRFMod.Ui.Widgets;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.UI;
+#if BEPINEX
+using TMPro;
+#elif MELONLOADER
+using Il2CppTMPro;
+#endif
+
+namespace TnTRFMod.Scenes.Enso;
+
+/// <summary>
+/// A judgement timing error bar overlay inspired by YunYunJudge.
+/// Displays colored timing window segments, tick marks for recent hits,
+/// and triangles indicating short-term and long-term average offset.
+/// </summary>
+public class JudgementBarOverlay
+{
+    private const int MaxRecentHits = 50;
+    private const float BarWidth = 576f;
+    private const float BarHeight = 32f;
+    private const float BottomPadding = 40f;
+    private const float TickWidth = 2f;
+    private const float TriangleSize = 12f;
+    private const float BackgroundPadding = 6f;
+
+    // Static queue for receiving hit offsets directly from EnsoGameBasePatch
+    private static readonly Queue<float> _pendingOffsets = new();
+    private static readonly object _pendingLock = new();
+
+    /// <summary>
+    /// Called from EnsoGameBasePatch.OnSimpleHit to feed exact per-hit offsets.
+    /// </summary>
+    public static void PushHitOffsetFromPatch(float offsetMs)
+    {
+        lock (_pendingLock)
+        {
+            _pendingOffsets.Enqueue(offsetMs);
+        }
+    }
+
+    // Recent hit offsets (circular buffer)
+    private readonly float[] _recentHits = new float[MaxRecentHits];
+    private int _recentHitIndex;
+    private int _recentHitCount;
+    private float _recentHitSum;
+
+    // All-session hit tracking
+    private float _allHitSum;
+    private int _allHitCount;
+
+    // UI elements
+    private GameObject _barRoot;
+    private RectTransform _barRootTransform;
+
+    // Segment images (left to right): Fuka, Ka, Ryo, Center, Ryo, Ka, Fuka
+    private Image _segFukaLeft;
+    private Image _segKaLeft;
+    private Image _segRyoLeft;
+    private Image _segCenter;
+    private Image _segRyoRight;
+    private Image _segKaRight;
+    private Image _segFukaRight;
+
+    // Background
+    private Image _background;
+
+    // Tick marks for recent hits
+    private readonly Image[] _tickMarks = new Image[MaxRecentHits];
+
+    // Average indicator triangles
+    private RectTransform _avgRecentTriangle;
+    private RectTransform _avgAllTriangle;
+
+    // Average text
+    private TextUi _avgText;
+
+    // Timing range in ms (max displayable offset)
+    private float TimeRangeMs => ModConfig.JudgementBarTimeRange.Value;
+
+    private static Color ColorFuka => new(1f, 140f / 255f, 0f, 0.8f); // dark orange
+    private static Color ColorKa => new(0f, 128f / 255f, 0f, 0.8f); // dark green
+    private static Color ColorRyo => new(0f, 102f / 255f, 204f / 255f, 0.8f); // dark blue
+    private static Color ColorCenter => new(1f, 1f, 1f, 0.9f); // white
+    private static Color ColorBackground => new(0f, 0f, 0f, 0.75f);
+    private static Color ColorTick => new(1f, 1f, 1f, 0.9f);
+    private static Color ColorAvgRecent => new(1f, 0.55f, 0f, 1f); // orange
+    private static Color ColorAvgAll => new(1f, 1f, 0f, 1f); // yellow
+
+    public void Start()
+    {
+        ResetData();
+        CreateBarUI();
+    }
+
+    public void Update()
+    {
+        // Reset with backtick key (same as YunYunJudge)
+        if (Keyboard.current != null && Keyboard.current[Key.Backquote].wasPressedThisFrame)
+        {
+            ResetData();
+        }
+
+        // Drain all pending offsets from the patch callback
+        lock (_pendingLock)
+        {
+            while (_pendingOffsets.Count > 0)
+            {
+                PushHitOffset(_pendingOffsets.Dequeue());
+            }
+        }
+
+        UpdateTickMarks();
+        UpdateAverageIndicators();
+        UpdateSegmentWidths();
+    }
+
+    public void Destroy()
+    {
+        _avgText?.Dispose();
+        if (_barRoot != null)
+            UnityEngine.Object.Destroy(_barRoot);
+    }
+
+    private void ResetData()
+    {
+        _recentHitIndex = 0;
+        _recentHitCount = 0;
+        _recentHitSum = 0;
+        _allHitSum = 0;
+        _allHitCount = 0;
+        Array.Clear(_recentHits, 0, _recentHits.Length);
+
+        lock (_pendingLock)
+        {
+            _pendingOffsets.Clear();
+        }
+    }
+
+    private void PushHitOffset(float offsetMs)
+    {
+        // Update all-session average
+        _allHitSum += offsetMs;
+        _allHitCount++;
+
+        // Update circular buffer for recent hits
+        if (_recentHitCount >= MaxRecentHits)
+        {
+            // Remove oldest value from sum
+            _recentHitSum -= _recentHits[_recentHitIndex];
+        }
+        else
+        {
+            _recentHitCount++;
+        }
+
+        _recentHits[_recentHitIndex] = offsetMs;
+        _recentHitSum += offsetMs;
+        _recentHitIndex = (_recentHitIndex + 1) % MaxRecentHits;
+    }
+
+    private void CreateBarUI()
+    {
+        // Root container for the bar, positioned at bottom-center of screen
+        _barRoot = new GameObject("JudgementBarOverlay");
+        _barRootTransform = _barRoot.AddComponent<RectTransform>();
+        _barRootTransform.SetParent(Common.GetDrawCanvasForScene(), false);
+        _barRootTransform.pivot = new Vector2(0.5f, 0f);
+        _barRootTransform.anchorMin = new Vector2(0.5f, 0f);
+        _barRootTransform.anchorMax = new Vector2(0.5f, 0f);
+        _barRootTransform.anchoredPosition = new Vector2(0f, BottomPadding);
+        _barRootTransform.sizeDelta = new Vector2(BarWidth, BarHeight);
+        _barRoot.layer = LayerMask.NameToLayer("UI");
+
+        // Background - covers the full visual area including diamond indicators and avg text
+        var totalHeight = BarHeight + (TriangleSize + 4f) * 2f + 24f; // bar + diamonds above/below + text line
+        _background = CreateColoredImage("BG", _barRootTransform, ColorBackground,
+            new Vector2(0f, -10f), new Vector2(BarWidth + BackgroundPadding * 2f, totalHeight + BackgroundPadding * 2f),
+            new Vector2(0.5f, 0.5f));
+
+        // Colored segments - will be sized dynamically based on judge ranges
+        var bandHeight = BarHeight * 0.5f;
+        var bandY = 0f; // centered vertically
+
+        // Create segments (initial sizes, will be updated in UpdateSegmentWidths)
+        _segFukaLeft = CreateColoredImage("SegFukaL", _barRootTransform, ColorFuka,
+            Vector2.zero, new Vector2(0, bandHeight), new Vector2(0.5f, 0.5f));
+        _segKaLeft = CreateColoredImage("SegKaL", _barRootTransform, ColorKa,
+            Vector2.zero, new Vector2(0, bandHeight), new Vector2(0.5f, 0.5f));
+        _segRyoLeft = CreateColoredImage("SegRyoL", _barRootTransform, ColorRyo,
+            Vector2.zero, new Vector2(0, bandHeight), new Vector2(0.5f, 0.5f));
+        _segCenter = CreateColoredImage("SegCenter", _barRootTransform, ColorCenter,
+            Vector2.zero, new Vector2(2f, bandHeight), new Vector2(0.5f, 0.5f));
+        _segRyoRight = CreateColoredImage("SegRyoR", _barRootTransform, ColorRyo,
+            Vector2.zero, new Vector2(0, bandHeight), new Vector2(0.5f, 0.5f));
+        _segKaRight = CreateColoredImage("SegKaR", _barRootTransform, ColorKa,
+            Vector2.zero, new Vector2(0, bandHeight), new Vector2(0.5f, 0.5f));
+        _segFukaRight = CreateColoredImage("SegFukaR", _barRootTransform, ColorFuka,
+            Vector2.zero, new Vector2(0, bandHeight), new Vector2(0.5f, 0.5f));
+
+        // Tick marks (hidden initially)
+        for (var i = 0; i < MaxRecentHits; i++)
+        {
+            _tickMarks[i] = CreateColoredImage($"Tick{i}", _barRootTransform, ColorTick,
+                Vector2.zero, new Vector2(TickWidth, BarHeight), new Vector2(0.5f, 0.5f));
+            _tickMarks[i].gameObject.SetActive(false);
+        }
+
+        // Average indicators (triangles approximated as narrow tall images)
+        _avgRecentTriangle = CreateTriangleIndicator("AvgRecent", _barRootTransform, ColorAvgRecent, true);
+        _avgAllTriangle = CreateTriangleIndicator("AvgAll", _barRootTransform, ColorAvgAll, false);
+
+        // Average text below the bar
+        _avgText = new TextUi(true)
+        {
+            Name = "JudgementBarAvgText",
+            Text = "",
+            FontSize = 24,
+            Alignment = TextAlignmentOptions.TopLeft,
+            Position = new Vector2(
+                (Common.ScreenWidth - BarWidth) / 2f,
+                Common.ScreenHeight - BottomPadding + 4f)
+        };
+    }
+
+    private void UpdateSegmentWidths()
+    {
+        var playerState = EnsoGameBasePatch.PlayerStates[0];
+        var ryoRange = playerState.RyoJudgeRange;
+        var kaRange = playerState.KaJudgeRange;
+        var fukaRange = playerState.FukaJudgeRange;
+        var timeRange = TimeRangeMs;
+
+        // If ranges aren't initialized yet, use defaults
+        if (ryoRange <= 0) ryoRange = 25f;
+        if (kaRange <= 0) kaRange = 75f;
+        if (fukaRange <= 0) fukaRange = 108f;
+
+        // Clamp ranges to our display range
+        ryoRange = Mathf.Min(ryoRange, timeRange);
+        kaRange = Mathf.Min(kaRange, timeRange);
+        fukaRange = Mathf.Min(fukaRange, timeRange);
+
+        var bandHeight = BarHeight * 0.5f;
+        var halfBar = BarWidth / 2f;
+
+        // Convert ms ranges to pixel widths
+        var ryoPixels = (ryoRange / timeRange) * halfBar;
+        var kaPixels = (kaRange / timeRange) * halfBar;
+        var fukaPixels = (fukaRange / timeRange) * halfBar;
+
+        // Center line
+        var centerRect = _segCenter.GetComponent<RectTransform>();
+        centerRect.anchoredPosition = Vector2.zero;
+        centerRect.sizeDelta = new Vector2(2f, bandHeight);
+
+        // Ryo segments (innermost colored band)
+        var segRyoLRect = _segRyoLeft.GetComponent<RectTransform>();
+        segRyoLRect.sizeDelta = new Vector2(ryoPixels, bandHeight);
+        segRyoLRect.anchoredPosition = new Vector2(-ryoPixels / 2f, 0f);
+
+        var segRyoRRect = _segRyoRight.GetComponent<RectTransform>();
+        segRyoRRect.sizeDelta = new Vector2(ryoPixels, bandHeight);
+        segRyoRRect.anchoredPosition = new Vector2(ryoPixels / 2f, 0f);
+
+        // Ka segments
+        var kaWidth = kaPixels - ryoPixels;
+        var segKaLRect = _segKaLeft.GetComponent<RectTransform>();
+        segKaLRect.sizeDelta = new Vector2(kaWidth, bandHeight);
+        segKaLRect.anchoredPosition = new Vector2(-(ryoPixels + kaWidth / 2f), 0f);
+
+        var segKaRRect = _segKaRight.GetComponent<RectTransform>();
+        segKaRRect.sizeDelta = new Vector2(kaWidth, bandHeight);
+        segKaRRect.anchoredPosition = new Vector2(ryoPixels + kaWidth / 2f, 0f);
+
+        // Fuka segments (outermost)
+        var fukaWidth = fukaPixels - kaPixels;
+        var segFukaLRect = _segFukaLeft.GetComponent<RectTransform>();
+        segFukaLRect.sizeDelta = new Vector2(fukaWidth, bandHeight);
+        segFukaLRect.anchoredPosition = new Vector2(-(kaPixels + fukaWidth / 2f), 0f);
+
+        var segFukaRRect = _segFukaRight.GetComponent<RectTransform>();
+        segFukaRRect.sizeDelta = new Vector2(fukaWidth, bandHeight);
+        segFukaRRect.anchoredPosition = new Vector2(kaPixels + fukaWidth / 2f, 0f);
+    }
+
+    private void UpdateTickMarks()
+    {
+        var timeRange = TimeRangeMs;
+        var halfBar = BarWidth / 2f;
+
+        for (var i = 0; i < MaxRecentHits; i++)
+        {
+            if (i >= _recentHitCount)
+            {
+                _tickMarks[i].gameObject.SetActive(false);
+                continue;
+            }
+
+            _tickMarks[i].gameObject.SetActive(true);
+            var offset = Mathf.Clamp(_recentHits[i], -timeRange, timeRange);
+            var xPos = (offset / timeRange) * halfBar;
+            var tickRect = _tickMarks[i].GetComponent<RectTransform>();
+            tickRect.anchoredPosition = new Vector2(xPos, 0f);
+        }
+    }
+
+    private void UpdateAverageIndicators()
+    {
+        var timeRange = TimeRangeMs;
+        var halfBar = BarWidth / 2f;
+
+        // Recent average (last 50)
+        if (_recentHitCount > 0)
+        {
+            var avgRecent = _recentHitSum / _recentHitCount;
+            var xRecent = Mathf.Clamp(avgRecent, -timeRange, timeRange) / timeRange * halfBar;
+            _avgRecentTriangle.anchoredPosition = new Vector2(xRecent, BarHeight / 2f + TriangleSize / 2f + 2f);
+            _avgRecentTriangle.gameObject.SetActive(true);
+        }
+        else
+        {
+            _avgRecentTriangle.gameObject.SetActive(false);
+        }
+
+        // All-session average
+        if (_allHitCount > 0)
+        {
+            var avgAll = _allHitSum / _allHitCount;
+            var xAll = Mathf.Clamp(avgAll, -timeRange, timeRange) / timeRange * halfBar;
+            _avgAllTriangle.anchoredPosition = new Vector2(xAll, -(BarHeight / 2f + TriangleSize / 2f + 2f));
+            _avgAllTriangle.gameObject.SetActive(true);
+
+            _avgText.Text = $"Avg: {avgAll:F1}ms";
+        }
+        else
+        {
+            _avgAllTriangle.gameObject.SetActive(false);
+            _avgText.Text = "";
+        }
+    }
+
+    private static Image CreateColoredImage(string name, RectTransform parent, Color color,
+        Vector2 position, Vector2 size, Vector2 pivot)
+    {
+        var go = new GameObject(name);
+        var rect = go.AddComponent<RectTransform>();
+        rect.SetParent(parent, false);
+        rect.pivot = pivot;
+        rect.anchorMin = new Vector2(0.5f, 0.5f);
+        rect.anchorMax = new Vector2(0.5f, 0.5f);
+        rect.anchoredPosition = position;
+        rect.sizeDelta = size;
+        go.layer = LayerMask.NameToLayer("UI");
+
+        var tex = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+        tex.SetPixel(0, 0, Color.white);
+        tex.Apply();
+
+        var image = go.AddComponent<Image>();
+        image.sprite = Sprite.Create(tex, new Rect(0, 0, 1, 1), new Vector2(0.5f, 0.5f));
+        image.color = color;
+        image.raycastTarget = false;
+
+        return image;
+    }
+
+    /// <summary>
+    /// Creates a diamond/triangle indicator using a rotated square image.
+    /// </summary>
+    private static RectTransform CreateTriangleIndicator(string name, RectTransform parent, Color color, bool pointUp)
+    {
+        var go = new GameObject(name);
+        var rect = go.AddComponent<RectTransform>();
+        rect.SetParent(parent, false);
+        rect.pivot = new Vector2(0.5f, 0.5f);
+        rect.anchorMin = new Vector2(0.5f, 0.5f);
+        rect.anchorMax = new Vector2(0.5f, 0.5f);
+        rect.sizeDelta = new Vector2(TriangleSize, TriangleSize);
+        rect.localRotation = Quaternion.Euler(0, 0, 45f); // rotate square to diamond
+        go.layer = LayerMask.NameToLayer("UI");
+
+        var tex = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+        tex.SetPixel(0, 0, Color.white);
+        tex.Apply();
+
+        var image = go.AddComponent<Image>();
+        image.sprite = Sprite.Create(tex, new Rect(0, 0, 1, 1), new Vector2(0.5f, 0.5f));
+        image.color = color;
+        image.raycastTarget = false;
+
+        go.SetActive(false);
+        return rect;
+    }
+}

--- a/src/Scenes/EnsoScene.cs
+++ b/src/Scenes/EnsoScene.cs
@@ -12,6 +12,7 @@ public class EnsoScene : IScene
 {
     private readonly HitOffsetTip HitOffsetTip = new();
     private readonly HitStatusPanel HitStatusPanel = new();
+    private readonly JudgementBarOverlay JudgementBarOverlay = new();
     private readonly ScoreRankIcon ScoreRankIcon = new();
 
     private readonly TokkunMode TokkunMode = new();
@@ -32,6 +33,7 @@ public class EnsoScene : IScene
         if (ModConfig.EnableNearestNeighborOnpuPatch.Value) NearestNeighborOnpuPatch.PatchLaneTarget();
         if (ModConfig.EnableHitStatsPanelPatch.Value) HitStatusPanel.Start();
         if (ModConfig.EnableHitOffset.Value) HitOffsetTip.Start();
+        if (ModConfig.EnableJudgementBar.Value) JudgementBarOverlay.Start();
         if (ModConfig.EnableTokkunGamePatch.Value) TokkunMode.Start();
 
         if (ModConfig.EnableScoreRankIcon.Value) ScoreRankIcon.Init();
@@ -40,6 +42,7 @@ public class EnsoScene : IScene
 
     public void Destroy()
     {
+        if (ModConfig.EnableJudgementBar.Value) JudgementBarOverlay.Destroy();
         if (ModConfig.EnableTokkunGamePatch.Value) TokkunMode.Destroy();
     }
 
@@ -48,6 +51,7 @@ public class EnsoScene : IScene
         if (ModConfig.EnableHitStatsPanelPatch.Value) HitStatusPanel.Update();
         if (ModConfig.EnableScoreRankIcon.Value) ScoreRankIcon.Update();
         if (ModConfig.EnableHitOffset.Value) HitOffsetTip.Update();
+        if (ModConfig.EnableJudgementBar.Value) JudgementBarOverlay.Update();
         if (ModConfig.EnableTokkunGamePatch.Value) TokkunMode.Update();
         // debugSmoothDeltaText.SetText("调试：音频延迟：{0:00.00}ms", (float)SmoothEnsoGamePatch.SmoothDelta);
     }

--- a/src/Scenes/EnsoTestScene.cs
+++ b/src/Scenes/EnsoTestScene.cs
@@ -8,6 +8,7 @@ public class EnsoTestScene : IScene
 {
     private readonly HitOffsetTip HitOffsetTip = new();
     private readonly HitStatusPanel HitStatusPanel = new();
+    private readonly JudgementBarOverlay JudgementBarOverlay = new();
 
     public string SceneName => "EnsoTest";
     public bool LowLatencyMode => true;
@@ -24,11 +25,18 @@ public class EnsoTestScene : IScene
         if (ModConfig.EnableNearestNeighborOnpuPatch.Value) NearestNeighborOnpuPatch.PatchLaneTarget();
         if (ModConfig.EnableHitStatsPanelPatch.Value) HitStatusPanel.Start();
         if (ModConfig.EnableHitOffset.Value) HitOffsetTip.Start();
+        if (ModConfig.EnableJudgementBar.Value) JudgementBarOverlay.Start();
+    }
+
+    public void Destroy()
+    {
+        if (ModConfig.EnableJudgementBar.Value) JudgementBarOverlay.Destroy();
     }
 
     public void Update()
     {
         if (ModConfig.EnableHitStatsPanelPatch.Value) HitStatusPanel.Update();
         if (ModConfig.EnableHitOffset.Value) HitOffsetTip.Update();
+        if (ModConfig.EnableJudgementBar.Value) JudgementBarOverlay.Update();
     }
 }


### PR DESCRIPTION
Adds a judgement bar overlay that displays hit timing distribution during gameplay. I've been adding judgement bar mods to multiple rhythm games and used YunYunJudge (https://github.com/mdnpascual/YunYunJudge) as a template since it's also a BepInEx mod.

Features

- Colored timing window segments based on actual game judge ranges (Ryo=blue, Ka=green, Fuka=orange)
- White tick marks showing the last 50 hit offsets
- Top diamond indicator for last-50-hits average (orange) and bottom diamond indicator for all-hits-since-reset average (yellow)
- Average offset text display
- Dark background overlay for readability
- Reset with backtick (`) key mid-song
- Auto-resets when entering or restarting a song
- Configurable via [JudgementBar] section in config.toml

Config
```
  [JudgementBar]
  Enable = true
  TimeRange = 150.0
```

Demo:

https://github.com/user-attachments/assets/84bec688-eede-457a-9246-4537dfb58e5a

Build Note

If you encounter a System.IO.FileNotFoundException for System.Text.Json, Version=10.0.0.0 at runtime, it's because Tomlyn 2.10.1 pulls in System.Text.Json 10.0.2 which is incompatible with the net6.0 BepInEx runtime. Since  Tomlyn isn't used anywhere in the codebase (only Tommy is used for TOML parsing), removing it from TnTRFMod.csproj fixes the issue:
```
       <!-- Common Libraries -->
       <ItemGroup>
  -        <PackageReference Include="Tomlyn" Version="2.10.1" />
           <PackageReference Include="Tommy" Version="3.1.2" />
       </ItemGroup>
```
